### PR TITLE
feat: query params to JSON

### DIFF
--- a/components/tools-list.ts
+++ b/components/tools-list.ts
@@ -35,4 +35,10 @@ export const tools = [
       "Easily convert epoch time (also known as Unix time or Unix timestamp) to a human-readable month/day/year and time format.",
     link: "utilities/timestamp-to-date",
   },
+  {
+    title: "Query params to JSON",
+    description:
+      "Convert URL query parameters into a structured JSON object, simplifying the process of parsing and manipulating URL data in web applications.",
+    link: "utilities/query-params-to-json",
+  },
 ];

--- a/pages/utilities/query-params-to-json.tsx
+++ b/pages/utilities/query-params-to-json.tsx
@@ -1,0 +1,104 @@
+import { useCallback, useState } from "react";
+import { Textarea } from "../../components/ds/TextareaComponent";
+import PageHeader from "../../components/PageHeader";
+import { Card } from "../../components/ds/CardComponent";
+import { Button } from "../../components/ds/ButtonComponent";
+import { Label } from "../../components/ds/LabelComponent";
+import Header from "../../components/Header";
+import { CMDK } from "../../components/CMDK";
+import { useCopyToClipboard } from "../../components/hooks/useCopyToClipboard";
+
+export default function QueryParamsToJSON() {
+  const [input, setInput] = useState("");
+  const [output, setOutput] = useState("");
+  const { buttonText, handleCopy } = useCopyToClipboard();
+
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+      const { value } = event.currentTarget;
+      setInput(value);
+
+      if (value.trim() === "") {
+        setOutput("");
+        return;
+      }
+
+      try {
+        const output = convertQueryParamsToJSON(value.trim());
+        setOutput(output);
+      } catch (error) {
+        setOutput("Invalid input, please provide valid query parameters");
+      }
+    },
+    []
+  );
+
+  return (
+    <main>
+      <Header />
+      <CMDK />
+
+      <section className="container max-w-2xl mb-12">
+        <PageHeader
+          title="Query Params to JSON"
+          description="Fast, free, open source, ad-free tools."
+          logoSrc="/logo.png"
+        />
+      </section>
+
+      <section className="container max-w-2xl">
+        <Card className="flex flex-col p-6 hover:shadow-none shadow-none rounded-xl">
+          <div>
+            <Label>Query Parameters</Label>
+            <Textarea
+              rows={6}
+              placeholder="Paste here"
+              onChange={handleChange}
+              className="mb-6"
+              value={input}
+            />
+            <Label>JSON Output</Label>
+            <Textarea value={output} rows={6} readOnly className="mb-4" />
+            <Button variant="outline" onClick={() => handleCopy(output)}>
+              {buttonText}
+            </Button>
+          </div>
+        </Card>
+      </section>
+    </main>
+  );
+}
+
+const convertQueryParamsToJSON = (input: string): string => {
+  let inputString = input;
+
+  if (!input.includes("://")) {
+    inputString = input.startsWith("?")
+      ? `https://example.com${input}`
+      : `https://example.com?${input}`;
+  }
+
+  const url = new URL(inputString);
+  const intermediateResult: { [key: string]: string | string[] } = {};
+
+  url.searchParams.forEach((value, key) => {
+    if (intermediateResult[key]) {
+      if (Array.isArray(intermediateResult[key])) {
+        intermediateResult[key].push(value);
+      } else {
+        intermediateResult[key] = [intermediateResult[key], value];
+      }
+    } else {
+      intermediateResult[key] = value;
+    }
+  });
+
+  const sortedKeys = Object.keys(intermediateResult).sort();
+  const result: { [key: string]: string | string[] } = {};
+
+  sortedKeys.forEach((key) => {
+    result[key] = intermediateResult[key];
+  });
+
+  return JSON.stringify(result, null, 2);
+};


### PR DESCRIPTION
This PR introduces a new utility function `convertQueryParamsToJSON` that transforms URL query parameters into a structured JSON format. Under the hood uses `URL` API for robust parameter parsing.

- Handles both full URLs and partial URL strings (path + query)
- Supports multiple occurrences of the same parameter
- Sorts keys alphabetically

---


<img width="1912" alt="image" src="https://github.com/user-attachments/assets/46a748dc-7cc8-4466-9616-d085947c5176">
