### PR TITLE
feat: add .env to netlify.toml converter

### DIFF
--- a/components/seo/EnvToTomlSEO.tsx
+++ b/components/seo/EnvToTomlSEO.tsx
@@ -1,0 +1,58 @@
+export default function EnvToTomlSEO() {
+  return (
+    <div className="content-wrapper">
+      <section>
+        <h2>Free, Open Source & Ad-free</h2>
+        <p>
+          This free tool allows you to quickly and easily convert your{" "}
+          <kbd>.env</kbd> file variables into the format needed for your{" "}
+          <kbd>netlify.toml</kbd> file. This tool was contributed to Jam's dev
+          utilities by{" "}
+          <a href="https://x.com/cassidoo" target="_blank" rel="noreferrer">
+            Cassidy Williams
+          </a>{" "}
+          - software engineer, dev advocate, startup advisor, and investor. You
+          can find her meming on Twitter and sharing learnings and tools for
+          developers in her{" "}
+          <a
+            href="https://cassidoo.co/newsletter/"
+            target="_blank"
+            rel="noreferrer"
+          >
+            newsletter.
+          </a>
+        </p>
+      </section>
+
+      <section>
+        <h2>How to Use:</h2>
+        <ol>
+          <li>
+            <b>Paste your variables:</b>
+            <br />
+            <p>
+              Copy the variables from your <kbd>.env</kbd> file and paste them
+              into the input box.
+            </p>
+          </li>
+          <li>
+            <b>Handles comments and empty lines:</b>
+            <br />
+            <p>
+              The tool works with comments and empty lines, so you don't need to
+              remove them manually.
+            </p>
+          </li>
+          <li>
+            <b>Copy the Result:</b>
+            <br />
+            <p>
+              Copy the converted output and paste it into your{" "}
+              <kbd>netlify.toml</kbd> file.
+            </p>
+          </li>
+        </ol>
+      </section>
+    </div>
+  );
+}

--- a/components/utils/env-to-toml.utils.test.ts
+++ b/components/utils/env-to-toml.utils.test.ts
@@ -1,0 +1,63 @@
+import { envToToml } from "./env-to-toml.utils";
+
+describe("envToToml", () => {
+  it("should return an empty string for empty input", () => {
+    const result = envToToml("");
+
+    expect(result).toBe("");
+  });
+
+  it("should convert a single environment variable", () => {
+    const envString = "KEY=value";
+    const expectedOutput = `[context.production]
+  environment = {KEY="value"}`;
+    const result = envToToml(envString);
+
+    expect(result).toBe(expectedOutput);
+  });
+
+  it("should convert multiple environment variables", () => {
+    const envString = "KEY1=value1\nKEY2=value2";
+    const expectedOutput = `[context.production]
+  environment = {KEY1="value1", KEY2="value2"}`;
+    const result = envToToml(envString);
+
+    expect(result).toBe(expectedOutput);
+  });
+
+  it("should ignore comments", () => {
+    const envString = "# This is a comment\nKEY=value";
+    const expectedOutput = `[context.production]
+  environment = {KEY="value"}`;
+    const result = envToToml(envString);
+
+    expect(result).toBe(expectedOutput);
+  });
+
+  it("should ignore empty lines", () => {
+    const envString = "\nKEY=value\n";
+    const expectedOutput = `[context.production]
+  environment = {KEY="value"}`;
+    const result = envToToml(envString);
+
+    expect(result).toBe(expectedOutput);
+  });
+
+  it("should ignore both comments and empty lines", () => {
+    const envString = "\n# Comment\nKEY1=value1\n\n# Comment\nKEY2=value2\n";
+    const expectedOutput = `[context.production]
+  environment = {KEY1="value1", KEY2="value2"}`;
+    const result = envToToml(envString);
+
+    expect(result).toBe(expectedOutput);
+  });
+
+  it("should handle values with existing double quotes", () => {
+    const envString = `NODE_VERSION="20.9.0"`;
+    const expectedOutput = `[context.production]
+  environment = {NODE_VERSION="20.9.0"}`;
+    const result = envToToml(envString);
+
+    expect(result).toBe(expectedOutput);
+  });
+});

--- a/components/utils/env-to-toml.utils.ts
+++ b/components/utils/env-to-toml.utils.ts
@@ -1,0 +1,25 @@
+/**
+ * Function to convert environment variables to Netlify TOML format.
+ * Contributed by Cassidy Williams: https://x.com/cassidoo
+ */
+export function envToToml(envString: string): string {
+  const lines = envString
+    .split("\n")
+    .filter((line) => line.trim() !== "" && !line.trim().startsWith("#"));
+
+  if (lines.length === 0) {
+    return "";
+  }
+
+  const environmentVariables = lines
+    .map((line) => {
+      const [key, value] = line.split("=");
+      const sanitizedValue = value.replace(/^"|"$/g, "");
+
+      return `${key}="${sanitizedValue}"`;
+    })
+    .join(", ");
+
+  return `[context.production]
+  environment = {${environmentVariables}}`;
+}

--- a/components/utils/tools-list.ts
+++ b/components/utils/tools-list.ts
@@ -47,4 +47,10 @@ export const tools = [
       "Convert HEX to RGB and generate CSS snippets for web, Swift, and Android with our easy-to-use color converter.",
     link: "/utilities/hex-to-rgb",
   },
+  {
+    title: "Convert .env to netlify.toml",
+    description:
+      "This free tool allows you to quickly and easily convert your .env file variables into the format needed for your netlify.toml file.",
+    link: "/utilities/env-to-netlify-toml",
+  },
 ];

--- a/pages/utilities/env-to-netlify-toml.tsx
+++ b/pages/utilities/env-to-netlify-toml.tsx
@@ -1,0 +1,77 @@
+import { useCallback, useState } from "react";
+import { Textarea } from "@/components/ds/TextareaComponent";
+import PageHeader from "@/components/PageHeader";
+import { Card } from "@/components/ds/CardComponent";
+import { Button } from "@/components/ds/ButtonComponent";
+import { Label } from "@/components/ds/LabelComponent";
+import Header from "@/components/Header";
+import { CMDK } from "@/components/CMDK";
+import { useCopyToClipboard } from "@/components/hooks/useCopyToClipboard";
+import CallToActionGrid from "@/components/CallToActionGrid";
+import Meta from "@/components/Meta";
+import { envToToml } from "@/components/utils/env-to-toml.utils";
+import EnvToTomlSEO from "@/components/seo/EnvToTomlSEO";
+
+export default function EnvToToml() {
+  const [input, setInput] = useState("");
+  const [output, setOutput] = useState("");
+  const { buttonText, handleCopy } = useCopyToClipboard();
+
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+      const { value } = event.currentTarget;
+      setInput(value);
+
+      try {
+        setOutput(envToToml(value.trim()));
+      } catch {
+        setOutput("Invalid input");
+      }
+    },
+    []
+  );
+
+  return (
+    <main>
+      <Meta
+        title="Convert .env to netlify.toml"
+        description="This free tool allows you to quickly and easily convert your .env file variables into the format needed for your netlify.toml file."
+      />
+      <Header />
+      <CMDK />
+
+      <section className="container max-w-2xl mb-12">
+        <PageHeader
+          title="Convert .env to netlify.toml"
+          description="Free, Open Source & Ad-free"
+        />
+      </section>
+
+      <section className="container max-w-2xl mb-6">
+        <Card className="flex flex-col p-6 hover:shadow-none shadow-none rounded-xl">
+          <div>
+            <Label>env</Label>
+            <Textarea
+              rows={6}
+              placeholder="Paste here"
+              onChange={handleChange}
+              className="mb-6"
+              value={input}
+            />
+            <Label>netlify.toml</Label>
+            <Textarea value={output} rows={6} readOnly className="mb-4" />
+            <Button variant="outline" onClick={() => handleCopy(output)}>
+              {buttonText}
+            </Button>
+          </div>
+        </Card>
+      </section>
+
+      <CallToActionGrid />
+
+      <section className="container max-w-2xl">
+        <EnvToTomlSEO />
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
This PR implements a conversion from `.env` file format to `netlify.toml` configuration. 

This feature is based on the contribution of [Cassidy Williams](https://github.com/cassidoo). You can find her on Twitter [@cassidoo](https://twitter.com/cassidoo).
