### PR TITLE
[Feature] - CSS Inliner for Email

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Here is the list of all utilities:
 - [HAR file viewer](https://jam.dev/utilities/har-file-viewer)
 - [JSON to YAML](https://jam.dev/utilities/json-to-yaml)
 - [Number Base Changer](https://jam.dev/utilities/number-base-changer)
-- [CSS to Inline Converter](https://jam.dev/utilities/css-to-inline-converter)
+- [CSS Inliner for Email](https://jam.dev/utilities/css-inliner-for-email)
 
 ### Built With
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Here is the list of all utilities:
 - [HAR file viewer](https://jam.dev/utilities/har-file-viewer)
 - [JSON to YAML](https://jam.dev/utilities/json-to-yaml)
 - [Number Base Changer](https://jam.dev/utilities/number-base-changer)
+- [CSS to Inline Converter](https://jam.dev/utilities/css-to-inline-converter)
 
 ### Built With
 

--- a/components/utils/css-to-inline.utils.test.ts
+++ b/components/utils/css-to-inline.utils.test.ts
@@ -1,0 +1,160 @@
+import { convertCSSToInline } from "./css-to-inline.utils";
+
+describe("convertCSSToInline", () => {
+  it("should apply inline styles from CSS to a more complex HTML structure while preserving classes", () => {
+    const html = `
+      <div id="main" class="container">
+        <header class="header">
+          <h1>Welcome</h1>
+          <nav class="nav">
+            <ul>
+              <li><a href="#home" class="nav-link">Home</a></li>
+              <li><a href="#about" class="nav-link">About</a></li>
+              <li><a href="#services" class="nav-link">Services</a></li>
+            </ul>
+          </nav>
+        </header>
+        <section class="content">
+          <p class="intro">This is a sample paragraph inside a section.</p>
+          <div class="highlight">
+            <span class="highlighted-text">Important Text</span>
+          </div>
+        </section>
+      </div>
+    `;
+
+    const css = `
+      .container {
+        max-width: 960px;
+        margin: 0 auto;
+        padding: 20px;
+        background-color: #f9f9f9;
+      }
+      .header {
+        background-color: #333;
+        color: #fff;
+        padding: 15px;
+        text-align: center;
+      }
+      .nav-link {
+        color: #007BFF;
+        text-decoration: none;
+        margin-right: 10px;
+      }
+      .content {
+        margin-top: 20px;
+      }
+      .intro {
+        font-size: 18px;
+        color: #555;
+      }
+      .highlight {
+        background-color: #ffeb3b;
+        padding: 10px;
+        border-radius: 5px;
+      }
+      .highlighted-text {
+        font-weight: bold;
+        color: #d32f2f;
+      }
+    `;
+
+    const result = convertCSSToInline(html, css);
+
+    const expected = `
+      <div id="main" class="container" style="max-width: 960px; margin: 0 auto; padding: 20px; background-color: #f9f9f9;">
+        <header class="header" style="background-color: #333; color: #fff; padding: 15px; text-align: center;">
+          <h1>Welcome</h1>
+          <nav class="nav">
+            <ul>
+              <li><a href="#home" class="nav-link" style="color: #007BFF; text-decoration: none; margin-right: 10px;">Home</a></li>
+              <li><a href="#about" class="nav-link" style="color: #007BFF; text-decoration: none; margin-right: 10px;">About</a></li>
+              <li><a href="#services" class="nav-link" style="color: #007BFF; text-decoration: none; margin-right: 10px;">Services</a></li>
+            </ul>
+          </nav>
+        </header>
+        <section class="content" style="margin-top: 20px;">
+          <p class="intro" style="font-size: 18px; color: #555;">This is a sample paragraph inside a section.</p>
+          <div class="highlight" style="background-color: #ffeb3b; padding: 10px; border-radius: 5px;">
+            <span class="highlighted-text" style="font-weight: bold; color: #d32f2f;">Important Text</span>
+          </div>
+        </section>
+      </div>
+    `.trim();
+
+    expect(result.trim()).toBe(expected);
+  });
+
+  it("should return the same HTML when CSS is empty", () => {
+    const html = `
+      <div class="container">
+        <p class="text">Sample text</p>
+      </div>
+    `;
+    const css = "";
+    const result = convertCSSToInline(html, css);
+
+    expect(result.trim()).toBe(html.trim());
+  });
+
+  it("should return the same HTML when CSS does not match any selectors", () => {
+    const html = `
+      <div class="container">
+        <p class="text">Sample text</p>
+      </div>
+    `;
+    const css = `
+      .non-existent-class {
+        color: green;
+      }
+    `;
+    const result = convertCSSToInline(html, css);
+
+    expect(result.trim()).toBe(html.trim());
+  });
+
+  it("should correctly apply the last defined style when CSS has conflicting styles for the same selector", () => {
+    const html = `
+      <div class="container">
+        <p class="text">Sample text</p>
+      </div>
+    `;
+    const css = `
+      .text {
+        color: red;
+      }
+      .text {
+        color: blue;
+      }
+    `;
+    const result = convertCSSToInline(html, css);
+    const expected = `
+      <div class="container">
+        <p class="text" style="color: blue;">Sample text</p>
+      </div>
+    `.trim();
+
+    expect(result.trim()).toBe(expected);
+  });
+
+  it("should not apply styles from CSS rules that do not match any elements", () => {
+    const html = `
+      <div class="container">
+        <p class="text">Sample text</p>
+      </div>
+    `;
+    const css = `
+      .non-matching-class {
+        color: red;
+      }
+    `;
+    const result = convertCSSToInline(html, css);
+    const expected = `
+      <div class="container">
+        <p class="text">Sample text</p>
+      </div>
+    `.trim();
+
+    expect(result.trim()).toBe(expected);
+  });
+});

--- a/components/utils/css-to-inline.utils.ts
+++ b/components/utils/css-to-inline.utils.ts
@@ -1,0 +1,45 @@
+export function convertCSSToInline(html: string, css: string): string {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, "text/html");
+
+  const rules = css
+    .split("}")
+    .map((rule) => rule.trim())
+    .filter(Boolean);
+
+  rules.forEach((rule) => {
+    const [selectors, styleString] = rule.split("{").map((part) => part.trim());
+
+    if (!selectors || !styleString) return;
+
+    const elements = doc.querySelectorAll(selectors);
+
+    elements.forEach((element) => {
+      const currentStyle = element.getAttribute("style") || "";
+      const styleMap: { [key: string]: string } = {};
+
+      currentStyle.split(";").forEach((styleRule) => {
+        const [property, value] = styleRule.split(":").map((s) => s.trim());
+        if (property && value) {
+          styleMap[property] = value;
+        }
+      });
+
+      styleString.split(";").forEach((styleRule) => {
+        const [property, value] = styleRule.split(":").map((s) => s.trim());
+        if (property && value) {
+          styleMap[property] = value;
+        }
+      });
+
+      const finalStyle =
+        Object.entries(styleMap)
+          .map(([property, value]) => `${property}: ${value}`)
+          .join("; ") + ";";
+
+      element.setAttribute("style", finalStyle);
+    });
+  });
+
+  return doc.body.innerHTML.trim();
+}

--- a/components/utils/tools-list.ts
+++ b/components/utils/tools-list.ts
@@ -83,4 +83,10 @@ export const tools = [
       "Easily convert numbers between different bases (binary, octal, decimal, hexadecimal) with our free online Number Base Changer.",
     link: "/utilities/number-base-changer",
   },
+  {
+    title: "CSS to Inline Converter",
+    description:
+      "Easily convert your CSS styles to inline styles directly in your HTML. Perfect for improving email compatibility and reducing external stylesheet dependencies.",
+    link: "/utilities/css-to-inline-converter",
+  },
 ];

--- a/components/utils/tools-list.ts
+++ b/components/utils/tools-list.ts
@@ -84,9 +84,9 @@ export const tools = [
     link: "/utilities/number-base-changer",
   },
   {
-    title: "CSS to Inline Converter",
+    title: "CSS Inliner for Email",
     description:
       "Easily convert your CSS styles to inline styles directly in your HTML. Perfect for improving email compatibility and reducing external stylesheet dependencies.",
-    link: "/utilities/css-to-inline-converter",
+    link: "/utilities/css-inliner-for-email",
   },
 ];

--- a/pages/utilities/css-inliner-for-email.tsx
+++ b/pages/utilities/css-inliner-for-email.tsx
@@ -11,7 +11,7 @@ import Meta from "@/components/Meta";
 import { convertCSSToInline } from "../../components/utils/css-to-inline.utils";
 import { CMDK } from "../../components/CMDK";
 
-export default function CSSToInlineConverter() {
+export default function CSSInlinerForEmail() {
   const [htmlInput, setHtmlInput] = useState("");
   const [cssInput, setCssInput] = useState("");
   const [output, setOutput] = useState("");
@@ -21,8 +21,7 @@ export default function CSSToInlineConverter() {
     const parser = new DOMParser();
     const doc = parser.parseFromString(html, "text/html");
 
-    const hasTags =
-      doc.body.innerHTML.trim() !== "" && doc.body.children.length > 0;
+    const hasTags = doc.body?.children.length > 0;
     const hasParsingErrors = doc.querySelectorAll("parsererror").length > 0;
 
     return hasTags && !hasParsingErrors;
@@ -58,28 +57,32 @@ export default function CSSToInlineConverter() {
     ];
 
     const errorMessage =
-      conditions.find((value) => value.condition)?.message || null;
+      conditions.find((value) => value.condition)?.message ?? "";
 
     try {
       const inlinedHtml = convertCSSToInline(htmlInput, cssInput);
-      setOutput(errorMessage ?? inlinedHtml);
-    } catch (errorMessage: unknown) {
-      setOutput(errorMessage as string);
+      setOutput(errorMessage || inlinedHtml);
+    } catch (error) {
+      if (error instanceof Error) {
+        setOutput(error.message);
+      } else {
+        setOutput(errorMessage);
+      }
     }
   }, [htmlInput, cssInput]);
 
   return (
     <main>
       <Meta
-        title="CSS to Inline Converter by Jam.dev | Free, Open Source & Ad-free"
-        description="Convert CSS styles to inline styles directly in your HTML with Jam's free CSS to inline converter. Just paste your HTML and CSS, and get the inlined HTML result."
+        title="CSS Inliner for Email by Jam.dev | Free, Open Source & Ad-free"
+        description="Convert CSS styles to inline styles directly in your HTML with Jam's free CSS Inliner for Email. Just paste your HTML and CSS, and get the inlined HTML result."
       />
       <Header />
       <CMDK />
 
       <section className="container max-w-2xl mb-12">
         <PageHeader
-          title="CSS to Inline Converter"
+          title="CSS Inliner for Email"
           description="Convert your CSS to inline styles quickly and easily."
         />
       </section>

--- a/pages/utilities/css-to-inline-converter.tsx
+++ b/pages/utilities/css-to-inline-converter.tsx
@@ -1,0 +1,124 @@
+import { useCallback, useState } from "react";
+import { Textarea } from "@/components/ds/TextareaComponent";
+import PageHeader from "@/components/PageHeader";
+import { Card } from "@/components/ds/CardComponent";
+import { Button } from "@/components/ds/ButtonComponent";
+import { Label } from "@/components/ds/LabelComponent";
+import Header from "@/components/Header";
+import { useCopyToClipboard } from "@/components/hooks/useCopyToClipboard";
+import CallToActionGrid from "@/components/CallToActionGrid";
+import Meta from "@/components/Meta";
+import { convertCSSToInline } from "../../components/utils/css-to-inline.utils";
+import { CMDK } from "../../components/CMDK";
+
+export default function CSSToInlineConverter() {
+  const [htmlInput, setHtmlInput] = useState("");
+  const [cssInput, setCssInput] = useState("");
+  const [output, setOutput] = useState("");
+  const { buttonText, handleCopy } = useCopyToClipboard();
+
+  function isValidHTML(html: string): boolean {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, "text/html");
+
+    const hasTags =
+      doc.body.innerHTML.trim() !== "" && doc.body.children.length > 0;
+    const hasParsingErrors = doc.querySelectorAll("parsererror").length > 0;
+
+    return hasTags && !hasParsingErrors;
+  }
+
+  const handleHtmlChange = useCallback(
+    (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setHtmlInput(event.currentTarget.value);
+    },
+    []
+  );
+
+  const handleCssChange = useCallback(
+    (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setCssInput(event.currentTarget.value);
+    },
+    []
+  );
+
+  const handleConvert = useCallback(() => {
+    const trimmedHtml = htmlInput.trim();
+    const trimmedCss = cssInput.trim();
+
+    const conditions = [
+      {
+        condition: !trimmedHtml || !trimmedCss,
+        message: "Please provide both HTML and CSS inputs.",
+      },
+      {
+        condition: !isValidHTML(trimmedHtml),
+        message: "Invalid HTML input. Please check your HTML.",
+      },
+    ];
+
+    const errorMessage =
+      conditions.find((value) => value.condition)?.message || null;
+
+    try {
+      const inlinedHtml = convertCSSToInline(htmlInput, cssInput);
+      setOutput(errorMessage ?? inlinedHtml);
+    } catch (errorMessage: unknown) {
+      setOutput(errorMessage as string);
+    }
+  }, [htmlInput, cssInput]);
+
+  return (
+    <main>
+      <Meta
+        title="CSS to Inline Converter by Jam.dev | Free, Open Source & Ad-free"
+        description="Convert CSS styles to inline styles directly in your HTML with Jam's free CSS to inline converter. Just paste your HTML and CSS, and get the inlined HTML result."
+      />
+      <Header />
+      <CMDK />
+
+      <section className="container max-w-2xl mb-12">
+        <PageHeader
+          title="CSS to Inline Converter"
+          description="Convert your CSS to inline styles quickly and easily."
+        />
+      </section>
+
+      <section className="container max-w-2xl mb-6">
+        <Card className="flex flex-col p-6 hover:shadow-none shadow-none rounded-xl">
+          <div>
+            <Label>HTML</Label>
+            <Textarea
+              rows={6}
+              placeholder="Paste HTML here"
+              onChange={handleHtmlChange}
+              className="mb-6"
+              value={htmlInput}
+            />
+
+            <Label>CSS</Label>
+            <Textarea
+              rows={6}
+              placeholder="Paste CSS here"
+              onChange={handleCssChange}
+              className="mb-6"
+              value={cssInput}
+            />
+
+            <Button onClick={handleConvert} className="mb-4">
+              Convert to Inline
+            </Button>
+
+            <Label>Inlined HTML</Label>
+            <Textarea value={output} rows={6} readOnly className="mb-4" />
+            <Button variant="outline" onClick={() => handleCopy(output)}>
+              {buttonText}
+            </Button>
+          </div>
+        </Card>
+      </section>
+
+      <CallToActionGrid />
+    </main>
+  );
+}


### PR DESCRIPTION
Hello!

This PR introduces a new `CSS to Inline Converter` page to the application, designed to help users easily convert CSS styles into inline styles within their HTML. This tool is especially useful for developers who need to improve email compatibility or reduce external stylesheet dependencies.

### Key Changes
1. **New Utility Function:**
   - A utility function was added to parse HTML and CSS, applying inline styles from the CSS to the corresponding elements in the HTML while preserving existing inline styles.
2. **Test Suite:**
   - Created comprehensive tests to validate the functionality of the `convertCSSToInline` function, ensuring it handles various scenarios such as conflicting styles, non-matching selectors, and empty inputs.
3. **New Page Component:**
   - Added a new page component that allows users to input HTML and CSS, convert the CSS to inline styles, and copy the result.
   - Includes input validation to ensure correct HTML is provided and handles errors.
   - Features copy-to-clipboard functionality for easily copying the inlined HTML output.
4. **Updated Tools List:**
   - The `tools` array was updated to include the new converter, making it accessible from the main tools page.
5. **Documentation Update:**
   - The README file was updated to include the new converter in the list of available utilities, with a direct link to the tool.

### Benefits
1. **Developer Efficiency:** This tool simplifies the process of converting CSS to inline styles, a common need for email template development and other scenarios where external stylesheets are not supported.
