### PR TITLE
feat: GitHubContribution now with support for multiple contributors

### DIFF
--- a/components/GitHubContribution.tsx
+++ b/components/GitHubContribution.tsx
@@ -1,7 +1,11 @@
 import { GitHubLogoIcon } from "@radix-ui/react-icons";
 
-interface GitHubContributionProps {
+interface Contributor {
   username: string;
+}
+
+interface GitHubContributionProps {
+  contributors: Contributor[];
 }
 
 export default function GitHubContribution(props: GitHubContributionProps) {
@@ -9,13 +13,16 @@ export default function GitHubContribution(props: GitHubContributionProps) {
     <section className="container max-w-2xl content-wrapper mb-6">
       <p className="flex items-center gap-2 justify-center">
         <span>Built by</span> <GitHubLogoIcon />
-        <a
-          href={`https://github.com/${props.username}`}
-          target="_blank"
-          rel="noreferrer"
-        >
-          @{props.username}
-        </a>
+        {props.contributors.map((contributor: Contributor) => (
+          <a
+            href={`https://github.com/${contributor.username}`}
+            target="_blank"
+            rel="noreferrer"
+            key={contributor.username}
+          >
+            @{contributor.username}
+          </a>
+        ))}
       </p>
     </section>
   );

--- a/pages/utilities/css-inliner-for-email.tsx
+++ b/pages/utilities/css-inliner-for-email.tsx
@@ -122,7 +122,7 @@ export default function CSSInlinerForEmail() {
         </Card>
       </section>
 
-      <GitHubContribution username="EduardoDePatta" />
+      <GitHubContribution contributors={[{ username: "EduardoDePatta" }]} />
       <CallToActionGrid />
     </main>
   );

--- a/pages/utilities/css-units-converter.tsx
+++ b/pages/utilities/css-units-converter.tsx
@@ -190,7 +190,7 @@ export default function CSSUnitsConverter() {
         </Card>
       </section>
 
-      <GitHubContribution username="franciscoaiolfi" />
+      <GitHubContribution contributors={[{ username: "franciscoaiolfi" }]} />
       <CallToActionGrid />
     </main>
   );

--- a/pages/utilities/image-resizer.tsx
+++ b/pages/utilities/image-resizer.tsx
@@ -313,7 +313,7 @@ export default function ImageResize() {
         </Card>
       </section>
 
-      <GitHubContribution username="EduardoDePatta" />
+      <GitHubContribution contributors={[{ username: "EduardoDePatta" }]} />
       <CallToActionGrid />
     </main>
   );

--- a/pages/utilities/regex-tester.tsx
+++ b/pages/utilities/regex-tester.tsx
@@ -116,7 +116,7 @@ export default function RegexTester() {
         </Card>
       </section>
 
-      <GitHubContribution username="shashankshet" />
+      <GitHubContribution contributors={[{ username: "shashankshet" }]} />
       <CallToActionGrid />
     </main>
   );


### PR DESCRIPTION
Hello everyone!

The GitHubContribution component was originally designed to credit only one contributor. It has now been updated to support multiple contributors. The component now accepts an array of contributor objects, for better recognition of multiple contributors on one utility.

Looking forward to hearing your feedback!