### PR TITLE
feat: add sample data button to csv to json converter

### DIFF
--- a/pages/utilities/csv-to-json.tsx
+++ b/pages/utilities/csv-to-json.tsx
@@ -22,6 +22,10 @@ export default function CSVtoJSON() {
   const [lowercase, setLowercase] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const SAMPLE_DATA = `Name,Age,Country
+John,25,USA
+Alice,30,Canada
+Bob,35,UK`;
 
   const handleChange = useCallback(
     (event: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -42,6 +46,13 @@ export default function CSVtoJSON() {
     },
     [lowercase]
   );
+
+  const handleFillSampleData = () => {
+    setInput(SAMPLE_DATA);
+    handleChange({
+      currentTarget: { value: SAMPLE_DATA },
+    } as React.ChangeEvent<HTMLTextAreaElement>);
+  };
 
   const toggleLowercase = useCallback(() => {
     setLowercase((prevValue) => {
@@ -219,9 +230,23 @@ export default function CSVtoJSON() {
             </div>
 
             <Textarea value={output} rows={6} readOnly className="mb-4" />
-            <Button variant="outline" onClick={() => handleCopy(output)}>
-              {buttonText}
-            </Button>
+            <div className="flex gap-2">
+              <Button variant="outline" onClick={() => handleCopy(output)}>
+                {buttonText}
+              </Button>
+              <Button variant="outline" onClick={handleFillSampleData}>
+                Fill Sample Data
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setInput("");
+                  setOutput("");
+                }}
+              >
+                Clear
+              </Button>
+            </div>
           </div>
         </Card>
       </section>

--- a/pages/utilities/csv-to-json.tsx
+++ b/pages/utilities/csv-to-json.tsx
@@ -47,12 +47,12 @@ Bob,35,UK`;
     [lowercase]
   );
 
-  const handleFillSampleData = () => {
+  const handleFillSampleData = useCallback(() => {
     setInput(SAMPLE_DATA);
     handleChange({
       currentTarget: { value: SAMPLE_DATA },
     } as React.ChangeEvent<HTMLTextAreaElement>);
-  };
+  }, []);
 
   const toggleLowercase = useCallback(() => {
     setLowercase((prevValue) => {
@@ -166,15 +166,25 @@ Bob,35,UK`;
           <div>
             <div className="flex justify-between items-center mb-2">
               <Label className="mb-0">CSV</Label>
-              <Button
-                variant="outline"
-                onClick={triggerFileInput}
-                type="button"
-                size="sm"
-                className="gap-2"
-              >
-                <UploadIcon className="w-[16px]" /> Upload CSV
-              </Button>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="gap-2"
+                  onClick={handleFillSampleData}
+                >
+                  Fill Sample Data
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={triggerFileInput}
+                  type="button"
+                  size="sm"
+                  className="gap-2"
+                >
+                  <UploadIcon className="w-[16px]" /> Upload CSV
+                </Button>
+              </div>
               <input
                 ref={fileInputRef}
                 type="file"
@@ -230,12 +240,9 @@ Bob,35,UK`;
             </div>
 
             <Textarea value={output} rows={6} readOnly className="mb-4" />
-            <div className="flex gap-2">
+            <div className="flex gap-2 justify-between">
               <Button variant="outline" onClick={() => handleCopy(output)}>
                 {buttonText}
-              </Button>
-              <Button variant="outline" onClick={handleFillSampleData}>
-                Fill Sample Data
               </Button>
               <Button
                 variant="outline"


### PR DESCRIPTION
- Add a 'Fill Sample Data' button
- Add a 'Clear'

![image](https://github.com/user-attachments/assets/8135983d-65da-480c-bb89-50808a5deb78)


Arguably useful... but when I click a "Try it" button, the first thing I do if there's no possible way to find sample data, is to search Google for sample data.