### PR TITLE
feat(har-file-viewer): add "Started at" column

### DIFF
--- a/pages/utilities/har-file-viewer.tsx
+++ b/pages/utilities/har-file-viewer.tsx
@@ -234,6 +234,7 @@ const HarTable = ({ entries }: HarTableProps) => {
             <th className={tableHeaderStyles}>Name</th>
             <th className={tableHeaderStyles}>Status</th>
             <th className={tableHeaderStyles}>Type</th>
+            <th className={tableHeaderStyles}>Started at</th>
             <th
               className={tableHeaderSortableStyles}
               onClick={() => handleSort("size")}
@@ -277,6 +278,9 @@ const HarTable = ({ entries }: HarTableProps) => {
                   {entry.response.content.mimeType}
                 </td>
                 <td className={cn(tableCellStyles, "cursor-pointer")}>
+                  {new Date(entry.startedDateTime).toLocaleTimeString()}
+                </td>
+                <td className={cn(tableCellStyles, "cursor-pointer")}>
                   {(entry.response.content.size / 1024).toFixed(1) + "kB"}
                 </td>
                 <td className={tableCellStyles}>
@@ -297,7 +301,7 @@ const HarTable = ({ entries }: HarTableProps) => {
 
               {expandedRow === index && (
                 <tr className={cn(index % 2 === 0 && tableRowOddStyles)}>
-                  <td colSpan={5} className={tableCellStyles}>
+                  <td colSpan={6} className={tableCellStyles}>
                     <ExpandedDetails entry={entry} />
                   </td>
                 </tr>


### PR DESCRIPTION
Requests have a "Started at" value that is very useful when you need to check:

- What time the request was initiated; 
- For how long the HAR has been recording;

![image](https://github.com/user-attachments/assets/6a4e6938-03b6-41fb-b4d2-8360dfcc7267)

### What about tests?

Couldn't find existing tests for Pages.