### PR TITLE
Remove permanent scrollbar in HAR file viewer container

### DIFF
--- a/pages/utilities/har-file-viewer.tsx
+++ b/pages/utilities/har-file-viewer.tsx
@@ -256,7 +256,7 @@ export default function HARFileViewer() {
             </div>
           </section>
 
-          <section className="container max-w-7xl overflow-y-scroll">
+          <section className="container max-w-7xl">
             {viewMode === "table" ? (
               <HarTable
                 entries={harData.log.entries}


### PR DESCRIPTION
It's unclear why `overflow-y: scroll` was added to this `<section>`. It doesn't have a fixed height, so it will expand to fit its contents. Having this style will only make the scrollbar appear at all times, even though it is not needed:

<details>
<summary>Screenshots of the issue</summary>

Chromium (Brave):
<img width="1278" height="663" alt="image" src="https://github.com/user-attachments/assets/cc3a865b-03b8-4218-b0a1-f7a750ef4b1a" />

Firefox:
<img width="1278" height="663" alt="image" src="https://github.com/user-attachments/assets/9585c559-54a2-4728-a078-e95da39e4142" />

</details>

Removing the class should allow both the code and the resulting view to be cleaner and more meaningful.
