### PR TITLE
Feat: File Integrity Checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Here is the list of all utilities:
 - [Random String Generator](https://jam.dev/utilities/random-string-generator)
 - [CSV file viewer](https://jam.dev/utilities/csv-file-viewer)
 - [JSONL Validator](https://jam.dev/utilities/jsonl-validator)
+- [File Integrity Checker](https://jam.dev/utilities/file-integrity-checker)
 
 ### Built With
 

--- a/__tests__/pages/utilities/file-integrity-checker.test.tsx
+++ b/__tests__/pages/utilities/file-integrity-checker.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import FileIntegrityChecker from "../../../pages/utilities/file-integrity-checker";
+
+describe("FileIntegrityChecker", () => {
+  test("computes the sha256 hash automatically as soon as a file is uploaded", async () => {
+    render(<FileIntegrityChecker />);
+
+    const user = userEvent.setup();
+    const file = new File(["hello world"], "hello.txt", {
+      type: "text/plain",
+    });
+
+    await user.upload(screen.getByTestId("input"), file);
+
+    expect(await screen.findByText(/sha-256 hash/i)).toBeInTheDocument();
+    expect(screen.getByDisplayValue(/^[a-f0-9]{64}$/i)).toBeInTheDocument();
+  });
+
+  test("switching algorithms clears the stale hash and recomputes for the new one", async () => {
+    render(<FileIntegrityChecker />);
+
+    const user = userEvent.setup();
+    const file = new File(["hello world"], "hello.txt", {
+      type: "text/plain",
+    });
+
+    await user.upload(screen.getByTestId("input"), file);
+    await screen.findByDisplayValue(/^[a-f0-9]{64}$/i); // sha256 by default
+
+    await user.selectOptions(screen.getByLabelText(/hash algorithm/i), "md5");
+
+    expect(await screen.findByText(/md5 hash/i)).toBeInTheDocument();
+    expect(
+      await screen.findByDisplayValue(/^[a-f0-9]{32}$/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/components/seo/FileIntegrityCheckerSEO.tsx
+++ b/components/seo/FileIntegrityCheckerSEO.tsx
@@ -1,0 +1,101 @@
+export default function FileIntegrityCheckerSEO() {
+  return (
+    <div className="content-wrapper">
+      <section>
+        <p>
+          Generate a checksum (hash) of any file to confirm it wasn&apos;t
+          corrupted during download or transfer, or tampered with along the way.
+          If the hash you calculate matches the hash published by the
+          file&apos;s source, the file is identical, byte for byte, to the
+          original.
+        </p>
+      </section>
+
+      <section>
+        <p>
+          Drop a file into the tool above or click to browse for one. Large
+          files are streamed in chunks, so there&apos;s no file size limit and
+          nothing is ever uploaded anywhere.
+        </p>
+      </section>
+
+      <section>
+        <h2>How to Check File Integrity</h2>
+        <ul>
+          <li>
+            <b>Drop in or browse for your file:</b> <br /> Drag and drop the
+            file directly or click to select it from your machine.
+          </li>
+          <li>
+            <b>Pick the algorithm:</b> <br /> Choose SHA-256, SHA-512, or MD5 to
+            match the hash you were given.
+          </li>
+          <li>
+            <b>Wait for the hash to generate:</b> <br /> Large files are
+            streamed in chunks, so even multi-gigabyte files can be checked
+            without running out of memory.
+          </li>
+          <li>
+            <b>Verify against a known hash:</b> <br /> Paste the published hash
+            into the verify field to confirm it matches.
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>SHA-256 vs SHA-512 vs MD5</h2>
+        <p>
+          SHA-256 is the most common choice today for verifying downloads and
+          software packages. SHA-512 offers a longer digest for the same family.
+          MD5 is faster and still widely used for detecting accidental
+          corruption, though it&apos;s not considered cryptographically secure
+          against deliberate tampering.
+        </p>
+      </section>
+
+      <section>
+        <h2>Why Use a File Integrity Checker?</h2>
+        <ul>
+          <li>
+            <b>Catch corrupted downloads:</b> <br /> A hash mismatch tells you
+            immediately if a download was interrupted or damaged in transit.
+          </li>
+          <li>
+            <b>Detect tampering:</b> <br /> Comparing against a
+            publisher-provided hash confirms a file wasn&apos;t altered before
+            it reached you.
+          </li>
+          <li>
+            <b>Works on any file size:</b> <br /> Chunked streaming means
+            multi-gigabyte files are checked without loading the whole file into
+            memory.
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>FAQs</h2>
+        <ul>
+          <li>
+            <b>Is this tool safe for large or sensitive files?</b> <br /> Yes.
+            Everything runs locally in your browser — files are never uploaded
+            anywhere.
+          </li>
+          <li>
+            <b>Which algorithm should I use?</b> <br /> Use whichever algorithm
+            matches the hash published by the file&apos;s source — SHA-256,
+            SHA-512, or MD5.
+          </li>
+          <li>
+            <b>Is there a file size limit?</b> <br /> No. Files are read and
+            hashed in chunks, so even very large files can be checked.
+          </li>
+          <li>
+            <b>Is my file sent to a server?</b> <br /> No. All hashing happens
+            locally in your browser. Your file never leaves your machine.
+          </li>
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/components/utils/tools-list.ts
+++ b/components/utils/tools-list.ts
@@ -209,4 +209,10 @@ export const tools = [
       "View, search, and filter CSV, TSV or LOG files with color-coded severity levels. Quickly scan through logs with Datadog-inspired faceted filtering.",
     link: "/utilities/csv-file-viewer",
   },
+  {
+    title: "File integrity checker",
+    description:
+      "Generate SHA-256, SHA-512, and MD5 checksums for files of any size, then verify them against a known hash to confirm the file wasn't corrupted or altered in transit.",
+    link: "/utilities/file-integrity-checker",
+  },
 ];

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,5 +1,18 @@
 import "@testing-library/jest-dom";
 
+// jsdom's Blob (and File, which extends it) doesn't implement arrayBuffer().
+// so polyfill via FileReader, which jsdom does support.
+if (!Blob.prototype.arrayBuffer) {
+  Blob.prototype.arrayBuffer = function (this: Blob) {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as ArrayBuffer);
+      reader.onerror = () => reject(reader.error);
+      reader.readAsArrayBuffer(this);
+    });
+  };
+}
+
 // There's no official way to mock next/navigation.
 // We just make it no-op for all tests.
 jest.mock("next/navigation", () => ({

--- a/pages/utilities/file-integrity-checker.tsx
+++ b/pages/utilities/file-integrity-checker.tsx
@@ -1,0 +1,347 @@
+import React, { useCallback, useState } from "react";
+import PageHeader from "@/components/PageHeader";
+import { Card } from "@/components/ds/CardComponent";
+import { Button } from "@/components/ds/ButtonComponent";
+import { Label } from "@/components/ds/LabelComponent";
+import { Textarea } from "@/components/ds/TextareaComponent";
+import Header from "@/components/Header";
+import UploadIcon from "@/components/icons/UploadIcon";
+import { useCopyToClipboard } from "@/components/hooks/useCopyToClipboard";
+import CallToActionGrid from "@/components/CallToActionGrid";
+import Meta from "@/components/Meta";
+import { CMDK } from "@/components/CMDK";
+import crypto from "crypto";
+import GitHubContribution from "@/components/GitHubContribution";
+import FileIntegrityCheckerSEO from "@/components/seo/FileIntegrityCheckerSEO";
+import { Flame } from "lucide-react";
+
+// hashFileChunked hashes only the algorithms passed to it in a single pass;
+// only the selected algorithm is computed at a time, so switching algorithms
+// after a hash exists triggers a re-read/re-hash of the file.
+const ALGORITHMS = ["sha256", "sha512", "md5"] as const;
+type Algorithm = (typeof ALGORITHMS)[number];
+
+const ALGORITHM_LABELS: Record<Algorithm, string> = {
+  sha256: "SHA-256",
+  sha512: "SHA-512",
+  md5: "MD5",
+};
+
+// 8MB chunks: file is read and hashed incrementally so memory use stays constant
+const CHUNK_SIZE = 8 * 1024 * 1024;
+
+interface AlgorithmOption {
+  value: Algorithm;
+  label: string;
+}
+
+const algorithmOptions: AlgorithmOption[] = ALGORITHMS.map((algo) => ({
+  value: algo,
+  label: ALGORITHM_LABELS[algo],
+}));
+
+type HashResults = Record<Algorithm, string>;
+
+async function hashFileChunked(
+  file: File,
+  algorithms: readonly Algorithm[],
+  onProgress: (percent: number) => void
+): Promise<HashResults> {
+  const hashes = algorithms.reduce(
+    (acc, algo) => {
+      acc[algo] = crypto.createHash(algo);
+      return acc;
+    },
+    {} as Record<Algorithm, crypto.Hash>
+  );
+
+  let offset = 0;
+  while (offset < file.size) {
+    const chunk = file.slice(offset, offset + CHUNK_SIZE);
+    const buffer = Buffer.from(await chunk.arrayBuffer());
+    for (const algo of algorithms) {
+      hashes[algo].update(buffer);
+    }
+    offset += CHUNK_SIZE;
+    onProgress(Math.min(100, Math.round((offset / file.size) * 100)));
+  }
+
+  // Empty file: loop above never runs, still needs a digest.
+  return algorithms.reduce((acc, algo) => {
+    acc[algo] = hashes[algo].digest("hex");
+    return acc;
+  }, {} as HashResults);
+}
+
+export default function FileIntegrityChecker() {
+  const [dropStatus, setDropStatus] = useState<
+    "idle" | "unsupported" | "hover"
+  >("idle");
+  const [fileName, setFileName] = useState("");
+  const [isHashing, setIsHashing] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [results, setResults] = useState<HashResults | null>(null);
+  const [error, setError] = useState("");
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [verifyInput, setVerifyInput] = useState("");
+  const [selectedAlgorithm, setSelectedAlgorithm] =
+    useState<Algorithm>("sha256");
+  const { buttonText, handleCopy } = useCopyToClipboard();
+
+  const computeHash = useCallback(async (file: File, algorithm: Algorithm) => {
+    setError("");
+    setVerifyInput("");
+    setProgress(0);
+    setResults(null);
+    setIsHashing(true);
+
+    try {
+      const hashes = await hashFileChunked(file, [algorithm], (percent) => {
+        setProgress(percent);
+      });
+      setResults(hashes);
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? `Failed to hash file: ${err.message}`
+          : "An unexpected error occurred while hashing the file."
+      );
+    } finally {
+      setIsHashing(false);
+    }
+  }, []);
+
+  const handleAlgorithmSelect = useCallback(
+    (value: string) => {
+      if (!ALGORITHMS.includes(value as Algorithm)) return;
+      const algorithm = value as Algorithm;
+      setSelectedAlgorithm(algorithm);
+      if (selectedFile) {
+        computeHash(selectedFile, algorithm);
+      }
+    },
+    [selectedFile, computeHash]
+  );
+
+  const processFile = useCallback(
+    (file: File) => {
+      setFileName(file.name);
+      setSelectedFile(file);
+      setError("");
+      setVerifyInput("");
+      setProgress(0);
+      computeHash(file, selectedAlgorithm);
+    },
+    [selectedAlgorithm, computeHash]
+  );
+
+  const handleFileChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.currentTarget.files?.[0];
+      event.currentTarget.value = "";
+      if (!file) return;
+      setDropStatus("idle");
+      processFile(file);
+    },
+    [processFile]
+  );
+
+  const handleDrop = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      const file = event.dataTransfer.files[0];
+      if (!file) {
+        setDropStatus("unsupported");
+        return;
+      }
+      setDropStatus("idle");
+      processFile(file);
+    },
+    [processFile]
+  );
+
+  const handleDragOver = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      setDropStatus("hover");
+    },
+    []
+  );
+
+  const handleVerifyChange = useCallback(
+    (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setVerifyInput(event.currentTarget.value);
+    },
+    []
+  );
+
+  const isMatch =
+    !!results &&
+    !!verifyInput.trim() &&
+    verifyInput.trim().toLowerCase() === results[selectedAlgorithm];
+
+  return (
+    <main>
+      <Meta
+        title="File Integrity Checker | Free, Open Source & Ad-free"
+        description="Check file integrity by generating SHA-256, SHA-512, and MD5 hashes for any file, then verify against a known hash."
+      />
+      <Header />
+      <CMDK />
+
+      <section className="max-w-2xl mx-auto mb-12">
+        <PageHeader
+          title="File Integrity Checker"
+          description="Fast, free, open source, ad-free tools."
+        />
+      </section>
+
+      <section className="container max-w-2xl mb-6">
+        <Card className="flex flex-col p-6 hover:shadow-none shadow-none rounded-xl">
+          <div
+            onDrop={handleDrop}
+            onDragOver={handleDragOver}
+            onDragLeave={() => setDropStatus("idle")}
+            className="relative flex flex-col border border-dashed border-border p-6 text-center text-muted-foreground rounded-lg min-h-40 items-center justify-center bg-muted"
+          >
+            <input
+              type="file"
+              data-testid="input"
+              onChange={handleFileChange}
+              disabled={isHashing}
+              className="absolute inset-0 w-full h-full opacity-0 cursor-pointer disabled:cursor-not-allowed"
+            />
+            <UploadIcon />
+            <div>
+              {dropStatus === "idle" && !fileName && (
+                <p>Drop any file here, or click to browse</p>
+              )}
+              {dropStatus === "hover" && (
+                <p className="flex items-center justify-center gap-1">
+                  Drop it like it's hot <Flame className="size-3" />
+                </p>
+              )}
+              {dropStatus === "unsupported" && (
+                <p>Couldn&apos;t read that file</p>
+              )}
+              {dropStatus === "idle" && fileName && (
+                <p className="truncate max-w-full">{fileName}</p>
+              )}
+            </div>
+          </div>
+
+          {fileName && (
+            <div
+              className={`mt-4 transition-opacity ${
+                isHashing ? "opacity-100" : "opacity-0"
+              }`}
+              aria-hidden={!isHashing}
+            >
+              <div className="h-2 w-full rounded-full bg-muted overflow-hidden">
+                <div
+                  className="h-full rounded-full bg-primary transition-all"
+                  style={{ width: `${isHashing ? progress : 0}%` }}
+                />
+              </div>
+              <p className="text-sm text-muted-foreground mt-2">
+                Hashing… {progress}%
+              </p>
+            </div>
+          )}
+
+          {error && <p className="text-sm text-destructive mt-4">{error}</p>}
+
+          {fileName && (
+            <div className="mt-4 space-y-4">
+              <Label htmlFor="algorithm-select">Hash Algorithm</Label>
+              <select
+                id="algorithm-select"
+                aria-label="Hash algorithm"
+                value={selectedAlgorithm}
+                onChange={(event) => handleAlgorithmSelect(event.target.value)}
+                className="flex h-10 w-full rounded-lg border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              >
+                {algorithmOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+
+              <Divider />
+
+              <div className="mt-4">
+                <Label>{ALGORITHM_LABELS[selectedAlgorithm]} Hash</Label>
+                <Textarea
+                  value={
+                    isHashing
+                      ? `Calculating…`
+                      : results
+                        ? results[selectedAlgorithm]
+                        : ""
+                  }
+                  placeholder="Hash will appear here"
+                  rows={2}
+                  readOnly
+                />
+                <Button
+                  variant="outline"
+                  className="mt-2"
+                  onClick={() =>
+                    results && handleCopy(results[selectedAlgorithm])
+                  }
+                  disabled={!results}
+                >
+                  {buttonText}
+                </Button>
+              </div>
+
+              <Divider />
+
+              <Label>Verify Hash (optional)</Label>
+              <Textarea
+                rows={2}
+                placeholder={`Paste a ${ALGORITHM_LABELS[selectedAlgorithm]} hash to verify it against the file above`}
+                value={verifyInput}
+                onChange={handleVerifyChange}
+                disabled={!results}
+                className="mb-2"
+                style={
+                  verifyInput.trim() && results
+                    ? {
+                        borderColor: isMatch ? "#16a34a" : "#dc2626",
+                        borderWidth: 2,
+                      }
+                    : undefined
+                }
+              />
+              <p
+                className={`text-sm min-h-[1.25rem] ${
+                  verifyInput.trim() && results
+                    ? isMatch
+                      ? "text-green-600"
+                      : "text-destructive"
+                    : "opacity-0"
+                }`}
+                aria-hidden={!(verifyInput.trim() && results)}
+              >
+                {isMatch ? "Match — file is intact" : "No match"}
+              </p>
+            </div>
+          )}
+        </Card>
+      </section>
+
+      <GitHubContribution username="hariharjeevan" />
+      <CallToActionGrid />
+
+      <section className="container max-w-2xl">
+        <FileIntegrityCheckerSEO />
+      </section>
+    </main>
+  );
+}
+
+const Divider = () => {
+  return <div className="h-[1px] bg-border my-6"></div>;
+};

--- a/pages/utilities/file-integrity-checker.tsx
+++ b/pages/utilities/file-integrity-checker.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useRef, useState } from "react";
 import PageHeader from "@/components/PageHeader";
 import { Card } from "@/components/ds/CardComponent";
 import { Button } from "@/components/ds/ButtonComponent";
@@ -15,9 +15,6 @@ import GitHubContribution from "@/components/GitHubContribution";
 import FileIntegrityCheckerSEO from "@/components/seo/FileIntegrityCheckerSEO";
 import { Flame } from "lucide-react";
 
-// hashFileChunked hashes only the algorithms passed to it in a single pass;
-// only the selected algorithm is computed at a time, so switching algorithms
-// after a hash exists triggers a re-read/re-hash of the file.
 const ALGORITHMS = ["sha256", "sha512", "md5"] as const;
 type Algorithm = (typeof ALGORITHMS)[number];
 
@@ -42,10 +39,15 @@ const algorithmOptions: AlgorithmOption[] = ALGORITHMS.map((algo) => ({
 
 type HashResults = Record<Algorithm, string>;
 
+function throwIfAborted(signal: AbortSignal) {
+  if (signal.aborted) throw new DOMException("Aborted", "AbortError");
+}
+
 async function hashFileChunked(
   file: File,
   algorithms: readonly Algorithm[],
-  onProgress: (percent: number) => void
+  onProgress: (percent: number) => void,
+  signal: AbortSignal
 ): Promise<HashResults> {
   const hashes = algorithms.reduce(
     (acc, algo) => {
@@ -57,8 +59,10 @@ async function hashFileChunked(
 
   let offset = 0;
   while (offset < file.size) {
+    throwIfAborted(signal);
     const chunk = file.slice(offset, offset + CHUNK_SIZE);
     const buffer = Buffer.from(await chunk.arrayBuffer());
+    throwIfAborted(signal);
     for (const algo of algorithms) {
       hashes[algo].update(buffer);
     }
@@ -87,8 +91,13 @@ export default function FileIntegrityChecker() {
   const [selectedAlgorithm, setSelectedAlgorithm] =
     useState<Algorithm>("sha256");
   const { buttonText, handleCopy } = useCopyToClipboard();
+  const abortControllerRef = useRef<AbortController | null>(null);
 
   const computeHash = useCallback(async (file: File, algorithm: Algorithm) => {
+    abortControllerRef.current?.abort();
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
     setError("");
     setVerifyInput("");
     setProgress(0);
@@ -96,18 +105,22 @@ export default function FileIntegrityChecker() {
     setIsHashing(true);
 
     try {
-      const hashes = await hashFileChunked(file, [algorithm], (percent) => {
-        setProgress(percent);
-      });
+      const hashes = await hashFileChunked(
+        file,
+        [algorithm],
+        (percent) => setProgress(percent),
+        controller.signal
+      );
       setResults(hashes);
     } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
       setError(
         err instanceof Error
           ? `Failed to hash file: ${err.message}`
           : "An unexpected error occurred while hashing the file."
       );
     } finally {
-      setIsHashing(false);
+      if (!controller.signal.aborted) setIsHashing(false);
     }
   }, []);
 


### PR DESCRIPTION
### Summary

Adds a new File Integrity Checker utility that lets users generate SHA-256, SHA-512, or MD5 hashes for any local file and verify them against a known hash; No file size limits.

### Features

- Chunked hashing (hashFileChunked): reads the file in 8MB slices via file.slice() and streams each chunk into crypto.createHash, so memory usage stays constant regardless of file size. 
- Algorithm selector (SHA-256 / SHA-512 / MD5). Switching algorithms after a hash has already been computed triggers a fresh read + hash for the newly selected algorithm rather than reusing stale state.

### Testing

Added file-integrity-checker.test.tsx covering:
- Uploading a file automatically computes and displays the SHA-256 hash (default algorithm) without requiring a manual "compute" action.
- Switching the algorithm selector (e.g. to MD5) clears the stale SHA-256 hash and recomputes/display the correct-length hash for the newly selected algorithm.
- Tested hash generation for a 11 GB file.

### Screenshot
<img width="1920" height="1080" alt="Screenshot from 2026-07-07 10-53-07" src="https://github.com/user-attachments/assets/ab04bdd2-cd4c-4e9b-befb-f1ad6ea670d6" />